### PR TITLE
Christian/observational mode v1

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -222,7 +222,8 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
         end_observation_here = g_pApp->m_const_params.observation_test_count + start_searching_here;
     }
 
-    for (uint64_t seqNo = start_searching_here; (seqNo < SIZE); seqNo += replyEvery) {
+    for (uint64_t i = start_searching_here; (counter < SIZE); i++) {
+        uint64_t seqNo = i * replyEvery;
         const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
         const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
 
@@ -399,7 +400,7 @@ void client_sig_handler(int signum) {
         if(g_pApp->m_const_params.measurement == TIME_BASED) {
             log_msg("Test end (interrupted by timer)");
         } else {
-            log_msg("Test end, observations taking too long (interrupted by timer)");
+            log_err("Test end, observations taking too long (interrupted by timer)");
         }
         break;
     case SIGINT:

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -762,6 +762,7 @@ template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
 void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doSendLoop() {
+    // cycle through all set fds in the array (with wrap around to beginning)
     for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
         client_send_burst(curr_fds);
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -64,12 +64,13 @@ void set_client_timer(struct itimerval *timer) {
 }
 
 //------------------------------------------------------------------------------
-/* set the timer on client based on observation parameter given by user */
+/* set the timer on client based on [-o observation] parameter given by user */
 void set_observation_timer(struct itimerval *timer) {
     // extra sec and extra msec will be excluded from results
-    timer->it_value.tv_sec =
-        (g_pApp->m_const_params.observation_test_duration + TEST_START_WARMUP_OBS +
-        TEST_START_COOLDOWN_OBS) >> 12; // Right shift by 12
+    uint32_t total_observations = TEST_START_WARMUP_OBS + TEST_START_COOLDOWN_OBS +
+                                  g_pApp->m_const_params.observation_test_duration;
+    uint32_t waiting_cap = (total_observations >> 12) + 1; // Gurantee at least 1 sec
+    timer->it_value.tv_sec = waiting_cap;
     timer->it_value.tv_sec++;
     timer->it_value.tv_usec = 0;
     timer->it_interval.tv_sec = 0;
@@ -172,14 +173,19 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
     TicksTime testEnd =
         g_pPacketTimes->getTxTime(sendCount); // will be "truncated" to last pong request packet
 
-    if (!g_pApp->m_const_params.pPlaybackVector &&                  // no warmup in playback mode
-            !g_pApp->m_const_params.observation_test_duration) {    // no observation mode
-        testStart += TicksDuration::TICKS1MSEC * TEST_START_WARMUP_MSEC;
-        testEnd -= TicksDuration::TICKS1MSEC * TEST_END_COOLDOWN_MSEC;
+    if (!g_pApp->m_const_params.pPlaybackVector) { // no warmup in playback mode
+        if(!g_pApp->m_const_params.observation_test_duration) { // observation has no timed warmup/cooldown
+            testStart += TicksDuration::TICKS1MSEC * TEST_START_WARMUP_MSEC;
+            testEnd -= TicksDuration::TICKS1MSEC * TEST_END_COOLDOWN_MSEC;
+        }
     }
     log_dbg("testStart: %.9lf sec testEnd: %.9lf sec",
             (double)testStart.debugToNsec() / 1000 / 1000 / 1000,
             (double)testEnd.debugToNsec() / 1000 / 1000 / 1000);
+    if(testEnd < testStart) {
+        log_msg_file2(f, "Test end before test start. Ending statistics early");
+        return;
+    }
 
     TicksDuration *pLat = new TicksDuration[SIZE];
     RecordLog *pFullLog = g_pApp->m_const_params.fileFullLog ? new RecordLog[SIZE] : NULL;
@@ -197,69 +203,67 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
     uint64_t end_observation_here = -1;
     bool observation_mode_used = false;
 
-    //Observation mode used
     if (g_pApp->m_const_params.observation_test_duration != 0) {
         observation_mode_used = true;
-        start_searching_here += TEST_START_WARMUP_OBS; // remove observational warmup 
-        end_observation_here = g_pApp->m_const_params.observation_test_duration + start_searching_here; // remove observational cooldown
+        start_searching_here += TEST_START_WARMUP_OBS;
+        end_observation_here = g_pApp->m_const_params.observation_test_duration + start_searching_here;
     }
-    if(testStart < testEnd) {
-        for (uint64_t seqNo = start_searching_here; (counter < SIZE) && (seqNo <= SIZE); seqNo += replyEvery) {
-            const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
-            const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
 
-            if ((txTime > testEnd) || (txTime == TicksTime::TICKS0)) {
-                break;
-            }
+    for (uint64_t seqNo = start_searching_here; (seqNo < SIZE); seqNo += replyEvery) {
+        const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
+        const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
 
-            if(observation_mode_used && seqNo >= end_observation_here) {
-                break;
-            }
-
-            if (txTime < testStart) {
-                continue;
-            }
-
-            if (startValidSeqNo == 0) {
-                startValidSeqNo = seqNo;
-                startValidTime = txTime; 
-            }
-
-            if (rxTime == TicksTime::TICKS0) {
-                g_pPacketTimes->incDroppedCount(SERVER_NO);
-                if (endValidTime < txTime) {
-                    endValidSeqNo = seqNo;
-                    endValidTime = txTime;
-                }
-                continue;
-            }
-
-            if (rxTime < prevRxTime) {
-                g_pPacketTimes->incOooCount(SERVER_NO);
-                continue;
-            }
-
-            if (g_pApp->m_const_params.fileFullLog) {
-                pFullLog[counter][0] = txTime;
-                pFullLog[counter][1] = rxTime;
-            }
-
-            endValidSeqNo = seqNo;
-            endValidTime = rxTime;
-
-            rtt = rxTime - txTime;
-
-            sumRtt += rtt;
-            pLat[counter] = rtt / denominator;
-
-            prevRxTime = rxTime;
-            counter++;
+        if ((txTime > testEnd) || (txTime == TicksTime::TICKS0)) {
+            break;
         }
+
+        if(observation_mode_used && seqNo >= end_observation_here) {
+            break;
+        }
+
+        if (txTime < testStart) {
+            continue;
+        }
+
+        if (startValidSeqNo == 0) {
+            startValidSeqNo = seqNo;
+            startValidTime = txTime;
+        }
+
+        if (rxTime == TicksTime::TICKS0) {
+            g_pPacketTimes->incDroppedCount(SERVER_NO);
+            if (endValidTime < txTime) {
+                endValidSeqNo = seqNo;
+                endValidTime = txTime;
+            }
+            continue;
+        }
+
+        if (rxTime < prevRxTime) {
+            g_pPacketTimes->incOooCount(SERVER_NO);
+            continue;
+        }
+
+        if (g_pApp->m_const_params.fileFullLog) {
+            pFullLog[counter][0] = txTime;
+            pFullLog[counter][1] = rxTime;
+        }
+
+        endValidSeqNo = seqNo;
+        endValidTime = rxTime;
+
+        rtt = rxTime - txTime;
+
+        sumRtt += rtt;
+        pLat[counter] = rtt / denominator;
+
+        prevRxTime = rxTime;
+        counter++;
     }
 
     if (!counter) {
         log_msg_file2(
-            f, "No valid observations found. Try tune parameters: --time/--mps/--reply-every");
+            f, "No valid observations found. Try tune parameters: --time/--observations/--mps/--reply-every");
     } else {
         TicksDuration validRunTime = endValidTime - startValidTime;
         log_msg_file2(f, "[Valid Duration] RunTime=%.3lf sec; SentMessages=%" PRIu64
@@ -309,7 +313,6 @@ void stream_statistics(Message *pMsgRequest) {
 
     const uint64_t sendCount = pMsgRequest->getSequenceCounter();
 
-    // Send only mode! // TODO: coello, look here
     if (g_skipCount) {
         log_msg("Total of %" PRIu64 " messages sent in %.3lf sec (%" PRIu64 " messages skipped)\n",
                 sendCount, totalRunTime.toDecimalUsec() / 1000000, g_skipCount);
@@ -698,17 +701,14 @@ template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
 void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doSendThenReceiveLoop() {
-    log_msg("Ping pong boys");
-    if (!g_pApp->m_const_params.observation_test_duration) {
-        // Time based 
+    if (!g_pApp->m_const_params.observation_test_duration) { // check for time or observation based
         // cycle through all set fds in the array (with wrap around to beginning)
         for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
             client_send_then_receive(curr_fds);
     } else {
-        // Observation based
         int seqNo = 0;
         int counter_valid = 0;
-        const int SERVER_NO = 0; // This is always zero
+        const int SERVER_NO = 0; // TODO: should be one per server (as of 1/27/21 sockperf handles only one server)
         const uint64_t replyEvery = g_pApp->m_const_params.reply_every;
         TicksTime testStart;
         TicksTime prevRxTime;
@@ -720,23 +720,21 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
         // cycle through all set fds in the array (with wrap around to beginning)
         for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd) {
             client_send_then_receive(curr_fds);
+
             if(seqNo == 0) {
                 testStart = g_pPacketTimes->getTxTime(replyEvery);
             }
-
             seqNo+= replyEvery;
             const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
             const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
-
-            if (txTime == TicksTime::TICKS0 || rxTime == TicksTime::TICKS0 ||
-                txTime < testStart || rxTime < prevRxTime) {
+            if (txTime == TicksTime::TICKS0 || txTime < testStart ||
+                rxTime == TicksTime::TICKS0 || rxTime < prevRxTime) {
                 continue;
             }
-            
             prevRxTime = rxTime;
             counter_valid++;
+
             if(counter_valid == stop_counting) {
-                printf("g_receiveCount: %" PRId64 "\n counter_valid: %d\n seqNo %d\n",g_receiveCount, counter_valid, seqNo);
                 g_b_exit = true;
             }
         }
@@ -748,30 +746,8 @@ template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
 void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doSendLoop() {
-    log_msg("doing doSendLoop");
-
-    // if (!g_pApp->m_const_params.observation_test_duration) {
-    //     // Time based
-        for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
-            client_send_burst(curr_fds);
-    // } else {
-    //     // Observation based
-    //     int warmup_observations = TEST_START_WARMUP_OBS; // TODO: coello, casting issue?
-    //     int cooldown_observations = TEST_START_COOLDOWN_OBS; // TODO: coello, casting issue?
-    //     int observation_target = g_pApp->m_const_params.observation_test_duration;
-    //     int stop_counting = warmup_observations + cooldown_observations + observation_target;
-    //     int counter = 0;
-    //     // cycle through all set fds in the array (with wrap around to beginning)
-    //     for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd) {
-    //         client_send_burst(curr_fds);
-    //         counter++;
-    //         if(counter >= stop_counting) {
-    //             s_endTime.setNowNonInline(); // End timestamp
-    //             g_b_exit = true;
-    //         }
-    //     }
-    //     log_msg("This is counter pollo: %d", counter);
-    // }
+    for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
+        client_send_burst(curr_fds);
 }
 
 //------------------------------------------------------------------------------
@@ -833,7 +809,7 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
         if (g_pApp->m_const_params.pPlaybackVector)
             doPlayback();
         else if (g_pApp->m_const_params.b_client_ping_pong)
-            doSendThenReceiveLoop(); // TODO: coello, remember to add observation for other modes
+            doSendThenReceiveLoop();
         else
             doSendLoop();
 

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -33,8 +33,8 @@
 /* Global variables */
 bool g_b_exit = false;
 bool g_b_errorOccured = false;
-uint64_t g_receiveCount = 0;    // TODO: should be one per server
-uint64_t g_skipCount = 0;       // TODO: should be one per server
+uint64_t g_receiveCount = 0; // TODO: should be one per server
+uint64_t g_skipCount = 0;    // TODO: should be one per server
 
 unsigned long long g_cycle_wait_loop_counter = 0;
 TicksTime g_cycleStartTime;

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -34,7 +34,6 @@
 bool g_b_exit = false;
 bool g_b_errorOccured = false;
 uint64_t g_receiveCount = 0;    // TODO: should be one per server
-uint64_t g_observableCount = 0; // TODO: should be one per server
 uint64_t g_skipCount = 0;       // TODO: should be one per server
 
 unsigned long long g_cycle_wait_loop_counter = 0;

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -33,8 +33,9 @@
 /* Global variables */
 bool g_b_exit = false;
 bool g_b_errorOccured = false;
-uint64_t g_receiveCount = 0; // TODO: should be one per server
-uint64_t g_skipCount = 0;    // TODO: should be one per server
+uint64_t g_receiveCount = 0;    // TODO: should be one per server
+uint64_t g_observableCount = 0; // TODO: should be one per server
+uint64_t g_skipCount = 0;       // TODO: should be one per server
 
 unsigned long long g_cycle_wait_loop_counter = 0;
 TicksTime g_cycleStartTime;

--- a/src/defs.h
+++ b/src/defs.h
@@ -123,6 +123,8 @@ const uint32_t REPLY_EVERY_DEFAULT = 100;
 
 const uint32_t TEST_START_WARMUP_MSEC = 400;
 const uint32_t TEST_END_COOLDOWN_MSEC = 50;
+const uint32_t TEST_START_WARMUP_OBS = 8000;
+const uint32_t TEST_START_COOLDOWN_OBS = 1000;
 
 const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC (0.1)
@@ -160,6 +162,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
+#define MAX_OBSERVATION 1000000 // TODO: coello, not sure on this value
 extern const int MAX_FDS_NUM;
 #define SOCK_BUFF_DEFAULT_SIZE 0
 #define DEFAULT_SELECT_TIMEOUT_MSEC 10
@@ -626,6 +629,7 @@ struct user_params_t {
     int msg_size;
     int msg_size_range;
     int sec_test_duration;
+    int observation_test_duration;
     bool data_integrity;
     fd_block_handler_t fd_handler_type;
     unsigned int packetrate_stats_print_ratio;
@@ -679,6 +683,7 @@ struct user_params_t {
     uint32_t dummy_mps;                   // client side only
     TicksDuration dummySendCycleDuration; // client side only
     uint32_t rate_limit;
+
 };
 
 struct mutable_params_t {};

--- a/src/defs.h
+++ b/src/defs.h
@@ -124,7 +124,7 @@ const uint32_t REPLY_EVERY_DEFAULT = 100;
 const uint32_t TEST_START_WARMUP_MSEC = 400;
 const uint32_t TEST_END_COOLDOWN_MSEC = 50;
 const uint32_t TEST_START_WARMUP_OBS = 8000;
-const uint32_t TEST_START_COOLDOWN_OBS = 1000;
+const uint32_t TEST_END_COOLDOWN_OBS = 1000;
 
 const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC (0.1)
@@ -162,7 +162,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
-#define MAX_OBSERVATION 1000000 // TODO: coello, not sure on this value
+#define MAX_OBSERVATIONS 10000000 // TODO: coello, not sure on this value
 extern const int MAX_FDS_NUM;
 #define SOCK_BUFF_DEFAULT_SIZE 0
 #define DEFAULT_SELECT_TIMEOUT_MSEC 10
@@ -646,6 +646,8 @@ struct user_params_t {
     unsigned int pre_warmup_wait;
     uint32_t cooldown_msec;
     uint32_t warmup_msec;
+    uint32_t cooldown_obs;
+    uint32_t warmup_obs;
     bool is_vmarxfiltercb;
     bool is_vmazcopyread;
     TicksDuration cycleDuration;
@@ -683,7 +685,6 @@ struct user_params_t {
     uint32_t dummy_mps;                   // client side only
     TicksDuration dummySendCycleDuration; // client side only
     uint32_t rate_limit;
-
 };
 
 struct mutable_params_t {};

--- a/src/defs.h
+++ b/src/defs.h
@@ -163,7 +163,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
-#define MAX_OBSERVATIONS 10000000 // TODO: coello, not sure on this value
+#define MAX_OBSERVATIONS 100000000 // TODO: coello, not sure on this value
 extern const int MAX_FDS_NUM;
 #define SOCK_BUFF_DEFAULT_SIZE 0
 #define DEFAULT_SELECT_TIMEOUT_MSEC 10
@@ -628,7 +628,7 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     FD_HANDLE_MAX } fd_block_handler_t;
 
 struct user_params_t {
-    work_mode_t mode; // either  client or server
+    work_mode_t mode; // either client or server
     measurement_mode_t measurement; // either time or observation
     struct in_addr rx_mc_if_addr;
     struct in_addr tx_mc_if_addr;

--- a/src/defs.h
+++ b/src/defs.h
@@ -132,6 +132,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_CLIENT_WORK_WITH_SRV_NUM 1
 
 #define DEFAULT_TEST_DURATION 1 /* [sec] */
+#define DEFAULT_OBSERVATION_COUNT 0
 #define DEFAULT_MC_ADDR "0.0.0.0"
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
@@ -610,6 +611,11 @@ typedef enum {
     MODE_BRIDGE
 } work_mode_t;
 
+typedef enum {
+    TIME_BASED = 1,
+    OBSERVATION_BASED
+} measurement_mode_t;
+
 typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     RECVFROM = 0,
     RECVFROMMUX,
@@ -623,13 +629,14 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
 
 struct user_params_t {
     work_mode_t mode; // either  client or server
+    measurement_mode_t measurement; // either time or observation
     struct in_addr rx_mc_if_addr;
     struct in_addr tx_mc_if_addr;
     struct in_addr mc_source_ip_addr;
     int msg_size;
     int msg_size_range;
     int sec_test_duration;
-    int observation_test_duration;
+    uint32_t observation_test_count;
     bool data_integrity;
     fd_block_handler_t fd_handler_type;
     unsigned int packetrate_stats_print_ratio;
@@ -646,8 +653,8 @@ struct user_params_t {
     unsigned int pre_warmup_wait;
     uint32_t cooldown_msec;
     uint32_t warmup_msec;
-    uint32_t cooldown_obs;
-    uint32_t warmup_obs;
+    uint64_t cooldown_obs;
+    uint64_t warmup_obs;
     bool is_vmarxfiltercb;
     bool is_vmazcopyread;
     TicksDuration cycleDuration;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -138,7 +138,7 @@ static const struct app_modes {
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
       { proc_mode_playback, "playback",
-        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined traffic, based "
+        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined traffic, based"
                                                   " on timeline and message size." },
       { proc_mode_throughput,  "throughput",
         aopt_set_string("tp"), "Run " MODULE_NAME " client for one way throughput test." },
@@ -743,7 +743,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         }
 
         if (!rc && aopt_check(self_obj, 'o')) {
-            const char *optarg = aopt_value(self_obj, 'o'); // TODO: coello, need to parse for all modes. This is just for ping-pong
+            const char *optarg = aopt_value(self_obj, 'o');
             if (optarg) {
                 errno = 0;
                 int value = strtol(optarg, NULL, 0);
@@ -2174,7 +2174,7 @@ void set_defaults() {
     g_fds_array = (fds_data **)MALLOC(MAX_FDS_NUM * sizeof(fds_data *));
     if (!g_fds_array) {
         log_err("Failed to allocate memory for global pointer fds_array");
-        exit_with_log(SOCKPERF_ERR_NO_MEMORY); // TODO: This  does not exit properly I think.
+        exit_with_log(SOCKPERF_ERR_NO_MEMORY);
     }
     int igmp_max_memberships = read_int_from_sys_file("/proc/sys/net/ipv4/igmp_max_memberships");
     if (igmp_max_memberships != -1) IGMP_MAX_MEMBERSHIPS = igmp_max_memberships;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -650,7 +650,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           "Run for <sec> seconds (default 1, max = 36000000)." },
         { 'o',                                                 AOPT_ARG,
           aopt_set_literal('o'),                               aopt_set_string("observations"),
-          "Run for observations (default 0, max = 1000000)." },
+          "Run for observations (default 0, max = 10000000)." },
         { OPT_CLIENTPORT,
           AOPT_ARG,
           aopt_set_literal(0),
@@ -747,7 +747,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
             if (optarg) {
                 errno = 0;
                 int value = strtol(optarg, NULL, 0);
-                if (errno != 0 || value <= 0 || value > MAX_OBSERVATION) {
+                if (errno != 0 || value <= 0 || value > MAX_OBSERVATIONS) {
                     log_msg("'-%c' Invalid observations: %s", 'o', optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
@@ -3241,6 +3241,8 @@ int bringup(const int *p_daemonize) {
                 TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000,
                 (int)(TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000));
         }
+        s_user_params.warmup_obs = TEST_START_WARMUP_OBS; // TODO, coello: make user input possible? Not done for time-based
+        s_user_params.cooldown_obs = TEST_END_COOLDOWN_OBS; // TODO, coello: make user input possible? Not done for time-based
 
         uint64_t _maxTestDuration = 1 + s_user_params.sec_test_duration +
                                     (s_user_params.warmup_msec + s_user_params.cooldown_msec) /

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -423,6 +423,7 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
 
     /* Set default values */
     s_user_params.mode = MODE_CLIENT;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.mps = MPS_DEFAULT;
     s_user_params.reply_every = REPLY_EVERY_DEFAULT;
 
@@ -707,6 +708,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
     /* Set default values */
     s_user_params.mode = MODE_CLIENT;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.b_client_ping_pong = true;
     s_user_params.mps = UINT32_MAX;
     s_user_params.reply_every = 1;
@@ -723,24 +725,6 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
     /* Set command line specific values */
     if (!rc && self_obj) {
-        if (!rc && aopt_check(self_obj, 't')) {
-            const char *optarg = aopt_value(self_obj, 't');
-            if (optarg) {
-                errno = 0;
-                int value = strtol(optarg, NULL, 0);
-                if (errno != 0 || value <= 0 || value > MAX_DURATION) {
-                    log_msg("'-%c' Invalid duration: %s", 't', optarg);
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                } else {
-                    s_user_params.measurement = TIME_BASED;
-                    s_user_params.sec_test_duration = value;
-                }
-            } else {
-                log_msg("'-%c' Invalid value", 't');
-                rc = SOCKPERF_ERR_BAD_ARGUMENT;
-            }
-        }
-
         if (!rc && aopt_check(self_obj, 'o')) {
             const char *optarg = aopt_value(self_obj, 'o');
             if (optarg) {
@@ -750,15 +734,34 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     log_msg("'-%c' Invalid observations: %s", 'o', optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
-                    if (s_user_params.measurement == TIME_BASED) {
-                        log_msg("Can't have both time and observation based");
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                    }
                     s_user_params.measurement = OBSERVATION_BASED;
                     s_user_params.observation_test_count = value;
                 }
             } else {
                 log_msg("'-%c' Invalid value", 'o');
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, 't')) {
+            const char *optarg = aopt_value(self_obj, 't');
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value > MAX_DURATION) {
+                    log_msg("'-%c' Invalid duration: %s", 't', optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    if (s_user_params.measurement == OBSERVATION_BASED) {
+                        log_msg("Can't have both observation and time based");
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.measurement = TIME_BASED;
+                        s_user_params.sec_test_duration = value;
+                    }
+                }
+            } else {
+                log_msg("'-%c' Invalid value", 't');
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -1007,6 +1010,7 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
 
     /* Set default values */
     s_user_params.mode = MODE_CLIENT;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.b_stream = true;
     s_user_params.mps = UINT32_MAX;
     s_user_params.reply_every = 1 << (8 * sizeof(s_user_params.reply_every) - 2);
@@ -1251,6 +1255,7 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
 
     /* Set default values */
     s_user_params.mode = MODE_CLIENT;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.mps = MPS_DEFAULT;
     s_user_params.reply_every = REPLY_EVERY_DEFAULT;
 

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -899,10 +899,10 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         printf("%s: %s\n", display_opt(id, temp_buf, sizeof(temp_buf)), sockperf_modes[id].note);
         printf("\n");
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
-        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time]\n",
+        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time | -o observations]\n",
                sockperf_modes[id].name);
         printf(" " MODULE_NAME
-               " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time]\n",
+               " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time | -o observations]\n",
                sockperf_modes[id].name);
         printf("\n");
         printf("Options:\n");

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -137,9 +137,9 @@ static const struct app_modes {
         aopt_set_string("ul"), "Run " MODULE_NAME " client for latency under load test." },
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
-      { proc_mode_playback, "playback", aopt_set_string("pb"),
-        "Run " MODULE_NAME " client for latency test using playback of predefined traffic, based "
-        "on timeline and message size." },
+      { proc_mode_playback, "playback",
+        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined traffic, based "
+                                                  " on timeline and message size." },
       { proc_mode_throughput,  "throughput",
         aopt_set_string("tp"), "Run " MODULE_NAME " client for one way throughput test." },
       { proc_mode_server, "server", aopt_set_string("sr"), "Run " MODULE_NAME " as a server." },
@@ -723,6 +723,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
     /* Set command line specific values */
     if (!rc && self_obj) {
+        bool time_based_used = false;
         if (!rc && aopt_check(self_obj, 't')) {
             const char *optarg = aopt_value(self_obj, 't');
             if (optarg) {
@@ -732,6 +733,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     log_msg("'-%c' Invalid duration: %s", 't', optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
+                    time_based_used = true;
                     s_user_params.sec_test_duration = value;
                 }
             } else {
@@ -741,7 +743,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         }
 
         if (!rc && aopt_check(self_obj, 'o')) {
-            const char *optarg = aopt_value(self_obj, 'o');
+            const char *optarg = aopt_value(self_obj, 'o'); // TODO: coello, need to parse for all modes. This is just for ping-pong
             if (optarg) {
                 errno = 0;
                 int value = strtol(optarg, NULL, 0);
@@ -749,6 +751,10 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     log_msg("'-%c' Invalid observations: %s", 'o', optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
+                    if (time_based_used) {
+                        log_msg("Can't have both time and observation based");
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    }
                     s_user_params.observation_test_duration = value;
                 }
             } else {


### PR DESCRIPTION
Draft

**Motive:**
Add observational-based measurement to ping-pong for sockperf.

Currently, sockperf runs until a timer completes producing an undetermined number of data rows. Knowing the exact number of test observations (rx/tx ping-pong reported) will make it easier to compare sockperf runs between two machines when they have the same number of datapoints. Another problem this solves is potential overflow of data collected during a post-processing of sockperf data, observational takes out the guess work. 

**Changes:**
- Parser accepts `-o` for number of observations for ping-pong mode
- Observational warmup/cooldown when in observational mode instead of adding time to timer
- Tracking valid observations in `doSendThenReceiveLoop()`,  where ` client_send_then_receive` is blocking
- Timer to stop waiting on observations if taking too long
- Time or Observational mode may be selected but not both

**Tested:** 
Ran server and client on same machine and manually verified log.txt had the expected observational data count.
`./sockperf sr -i 127.0.0.1`
`./sockperf pp -i 127.0.0.1 -o 1000 -m 64 --full-log log.txt`
