### PR TITLE
Add observation-based measurement for ping pong

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -64,6 +64,18 @@ void set_client_timer(struct itimerval *timer) {
 }
 
 //------------------------------------------------------------------------------
+/* set the timer on client based on [-o observation] parameter given by user */
+void set_observation_timer(struct itimerval *timer) {
+    uint32_t total_observations = s_user_params.warmup_obs + s_user_params.cooldown_obs +
+                                  g_pApp->m_const_params.observation_test_count;
+    uint32_t waiting_cap = (total_observations >> 12) + 1; // Gurantee at least 1 sec
+    timer->it_value.tv_sec = waiting_cap;
+    timer->it_value.tv_usec = 0;
+    timer->it_interval.tv_sec = 0;
+    timer->it_interval.tv_usec = 0;
+}
+
+//------------------------------------------------------------------------------
 void printPercentiles(FILE *f, TicksDuration *pLat, size_t size) {
     qsort(pLat, size, sizeof(TicksDuration), TicksDuration::compare);
 
@@ -126,16 +138,32 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
     if (SERVER_NO == 0) {
         TicksDuration totalRunTime = s_endTime - s_startTime;
         if (g_skipCount) {
-            log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
-                             " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64
+            if(g_pApp->m_const_params.measurement == TIME_BASED) {
+                log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
+                                " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64
+                                "; SkippedMessages=%" PRIu64 "",
+                            totalRunTime.toDecimalUsec() / 1000000,
+                            g_pApp->m_const_params.warmup_msec, sendCount, receiveCount, g_skipCount);
+            } else {
+            log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up observations=%" PRIu64
+                             "; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64
                              "; SkippedMessages=%" PRIu64 "",
                           totalRunTime.toDecimalUsec() / 1000000,
-                          g_pApp->m_const_params.warmup_msec, sendCount, receiveCount, g_skipCount);
+                          g_pApp->m_const_params.warmup_obs, sendCount, receiveCount, g_skipCount);
+            }
         } else {
-            log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
-                             " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64 "",
-                          totalRunTime.toDecimalUsec() / 1000000,
-                          g_pApp->m_const_params.warmup_msec, sendCount, receiveCount);
+            if(g_pApp->m_const_params.measurement == TIME_BASED) {
+                log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
+                                " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64 "",
+                            totalRunTime.toDecimalUsec() / 1000000,
+                            g_pApp->m_const_params.warmup_msec, sendCount, receiveCount);
+            }
+            else {
+                log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up observations=%" PRIu64
+                                "; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64 "",
+                            totalRunTime.toDecimalUsec() / 1000000,
+                            g_pApp->m_const_params.warmup_obs, sendCount, receiveCount);
+            }
         }
     }
 
@@ -160,12 +188,18 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
         g_pPacketTimes->getTxTime(sendCount); // will be "truncated" to last pong request packet
 
     if (!g_pApp->m_const_params.pPlaybackVector) { // no warmup in playback mode
-        testStart += TicksDuration::TICKS1MSEC * TEST_START_WARMUP_MSEC;
-        testEnd -= TicksDuration::TICKS1MSEC * TEST_END_COOLDOWN_MSEC;
+        if(g_pApp->m_const_params.measurement == TIME_BASED) {
+            testStart += TicksDuration::TICKS1MSEC * TEST_START_WARMUP_MSEC;
+            testEnd -= TicksDuration::TICKS1MSEC * TEST_END_COOLDOWN_MSEC;
+        }
     }
     log_dbg("testStart: %.9lf sec testEnd: %.9lf sec",
             (double)testStart.debugToNsec() / 1000 / 1000 / 1000,
             (double)testEnd.debugToNsec() / 1000 / 1000 / 1000);
+    if(testEnd < testStart) {
+        log_msg_file2(f, "Test end before test start. Ending statistics early");
+        return;
+    }
 
     TicksDuration *pLat = new TicksDuration[SIZE];
     RecordLog *pFullLog = g_pApp->m_const_params.fileFullLog ? new RecordLog[SIZE] : NULL;
@@ -173,19 +207,29 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
     TicksDuration rtt;
     TicksDuration sumRtt(0);
     size_t counter = 0;
-    size_t lcounter = 0;
     TicksTime prevRxTime;
     TicksTime startValidTime;
     TicksTime endValidTime;
     uint32_t denominator = g_pApp->m_const_params.full_rtt ? 1 : 2;
     uint64_t startValidSeqNo = 0;
     uint64_t endValidSeqNo = 0;
-    for (size_t i = 1; (counter < SIZE) && (testStart < testEnd); i++) {
+    uint64_t start_searching_here = 1;
+    uint64_t end_observation_here = -1;
+
+    if (g_pApp->m_const_params.measurement == OBSERVATION_BASED) {
+        end_observation_here = g_pApp->m_const_params.observation_test_count + start_searching_here;
+    }
+
+    for (uint64_t i = start_searching_here; (counter < SIZE); i++) {
         uint64_t seqNo = i * replyEvery;
         const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
         const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
 
         if ((txTime > testEnd) || (txTime == TicksTime::TICKS0)) {
+            break;
+        }
+
+        if(g_pApp->m_const_params.measurement == OBSERVATION_BASED && seqNo >= end_observation_here) {
             break;
         }
 
@@ -213,10 +257,9 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
         }
 
         if (g_pApp->m_const_params.fileFullLog) {
-            pFullLog[lcounter][0] = txTime;
-            pFullLog[lcounter][1] = rxTime;
+            pFullLog[counter][0] = txTime;
+            pFullLog[counter][1] = rxTime;
         }
-        lcounter++;
 
         endValidSeqNo = seqNo;
         endValidTime = rxTime;
@@ -232,7 +275,7 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
     if (!counter) {
         log_msg_file2(
-            f, "No valid observations found. Try tune parameters: --time/--mps/--reply-every");
+            f, "No valid observations found. Try tune parameters: --time/--observations/--mps/--reply-every");
     } else {
         TicksDuration validRunTime = endValidTime - startValidTime;
         log_msg_file2(f, "[Valid Duration] RunTime=%.3lf sec; SentMessages=%" PRIu64
@@ -266,7 +309,7 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
         printPercentiles(f, pLat, counter);
 
-        dumpFullLog(SERVER_NO, pFullLog, lcounter, pLat);
+        dumpFullLog(SERVER_NO, pFullLog, counter, pLat);
     }
 
     delete[] pLat;
@@ -352,7 +395,11 @@ void client_sig_handler(int signum) {
 
     switch (signum) {
     case SIGALRM:
-        log_msg("Test end (interrupted by timer)");
+        if(g_pApp->m_const_params.measurement == TIME_BASED) {
+            log_msg("Test end (interrupted by timer)");
+        } else {
+            log_err("Test ends uncompleted, observations taking too long (interrupted by timer)");
+        }
         break;
     case SIGINT:
         log_msg("Test end (interrupted by user)");
@@ -638,7 +685,11 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
 
                     if (!g_pApp->m_const_params.pPlaybackVector) {
                         struct itimerval timer;
-                        set_client_timer(&timer);
+                        if(g_pApp->m_const_params.measurement == TIME_BASED) {
+                            set_client_timer(&timer);
+                        } else {
+                            set_observation_timer(&timer);
+                        }
                         if (os_set_duration_timer(timer, client_sig_handler)) {
                             log_err("Failed setting test duration timer");
                             rc = SOCKPERF_ERR_FATAL;
@@ -663,9 +714,49 @@ template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
 void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doSendThenReceiveLoop() {
-    // cycle through all set fds in the array (with wrap around to beginning)
-    for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
-        client_send_then_receive(curr_fds);
+    if (g_pApp->m_const_params.measurement == TIME_BASED) {
+        // cycle through all set fds in the array (with wrap around to beginning)
+        for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
+            client_send_then_receive(curr_fds);
+    } else {
+        uint64_t seqNo = 0;
+        uint64_t counter_valid = 0;
+        const int SERVER_NO = 0; // TODO: should be one per server (as of 1/27/21 sockperf handles only one server)
+        const uint64_t replyEvery = g_pApp->m_const_params.reply_every;
+        TicksTime testStart;
+        TicksTime prevRxTime;
+        uint64_t warmup_observations = s_user_params.warmup_obs;
+        uint64_t cooldown_observations = s_user_params.cooldown_obs;
+        uint64_t observation_target = g_pApp->m_const_params.observation_test_count;
+        uint64_t stop_counting = warmup_observations + observation_target + cooldown_observations;
+
+        // cycle through all set fds in the array (with wrap around to beginning)
+        for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd) {
+            client_send_then_receive(curr_fds);
+
+            if(seqNo == 0) {
+                testStart = g_pPacketTimes->getTxTime(replyEvery); // first pong request packet
+            }
+
+            seqNo+= replyEvery;
+
+            // Validate observation
+            const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
+            const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
+            if (txTime == TicksTime::TICKS0 || txTime < testStart ||
+                rxTime == TicksTime::TICKS0 || rxTime < prevRxTime) {
+                continue;
+            }
+            prevRxTime = rxTime;
+            counter_valid++;
+
+            if(counter_valid == stop_counting) {
+                s_endTime.setNowNonInline();
+                log_msg("Test end (finished observation count)");
+                g_b_exit = true;
+            }
+        }
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/defs.h
+++ b/src/defs.h
@@ -123,6 +123,8 @@ const uint32_t REPLY_EVERY_DEFAULT = 100;
 
 const uint32_t TEST_START_WARMUP_MSEC = 400;
 const uint32_t TEST_END_COOLDOWN_MSEC = 50;
+const uint32_t TEST_START_WARMUP_OBS = 8000;
+const uint32_t TEST_END_COOLDOWN_OBS = 1000;
 
 const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC (0.1)
@@ -130,6 +132,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_CLIENT_WORK_WITH_SRV_NUM 1
 
 #define DEFAULT_TEST_DURATION 1 /* [sec] */
+#define DEFAULT_OBSERVATION_COUNT 0
 #define DEFAULT_MC_ADDR "0.0.0.0"
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
@@ -160,6 +163,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
+#define MAX_OBSERVATIONS 100000000 // TODO: coello, not sure on this value
 extern const int MAX_FDS_NUM;
 #define SOCK_BUFF_DEFAULT_SIZE 0
 #define DEFAULT_SELECT_TIMEOUT_MSEC 10
@@ -607,6 +611,11 @@ typedef enum {
     MODE_BRIDGE
 } work_mode_t;
 
+typedef enum {
+    TIME_BASED = 1,
+    OBSERVATION_BASED
+} measurement_mode_t;
+
 typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     RECVFROM = 0,
     RECVFROMMUX,
@@ -619,13 +628,15 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     FD_HANDLE_MAX } fd_block_handler_t;
 
 struct user_params_t {
-    work_mode_t mode; // either  client or server
+    work_mode_t mode; // either client or server
+    measurement_mode_t measurement; // either time or observation
     struct in_addr rx_mc_if_addr;
     struct in_addr tx_mc_if_addr;
     struct in_addr mc_source_ip_addr;
     int msg_size;
     int msg_size_range;
     int sec_test_duration;
+    uint32_t observation_test_count;
     bool data_integrity;
     fd_block_handler_t fd_handler_type;
     unsigned int packetrate_stats_print_ratio;
@@ -642,6 +653,8 @@ struct user_params_t {
     unsigned int pre_warmup_wait;
     uint32_t cooldown_msec;
     uint32_t warmup_msec;
+    uint64_t cooldown_obs;
+    uint64_t warmup_obs;
     bool is_vmarxfiltercb;
     bool is_vmazcopyread;
     TicksDuration cycleDuration;


### PR DESCRIPTION
**Motive:**
Add observational-based measurement to ping-pong scenario.

Currently, sockperf runs until a timer completes producing an undetermined number of data rows. Knowing the exact number of test observations (rx/tx ping-pongs reported) will make it easier to compare sockperf runs and avoids potential overflow during data collection.

**Changes:**
- Parser accepts `-n` for number of observations
- Observational warmup/cooldown when in observational mode instead of adding time to timer
- Tracking valid observations in `doSendThenReceiveLoop()`, where `client_send_then_receive` is blocking
- Timer to stop waiting on observations if taking too long

**Tested:**
Ran server and client locally and manually verified log.txt had the expected observational data count.
`./sockperf sr -i 127.0.0.1`
`./sockperf pp -i 127.0.0.1 -n 1000 -m 64 --full-log log.txt`