### PR TITLE
Add Stats

### DIFF
--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -297,6 +297,18 @@ const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key) {
     return value;
 }
 
+/**
+ * aopt_get_desc
+ *
+ * @brief
+ *    Return AOPT Description struct of option selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to description struct - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
 const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
     if (key == 0) {
         log_err("Not a valid key for aopt");
@@ -317,6 +329,18 @@ const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
     return desc;
 }
 
+/**
+ * aopt_get_long_name
+ *
+ * @brief
+ *    Return long name of option description selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to string - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
 const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key) {
     if (key == 0) {
         log_err("Not a valid key for aopt");
@@ -325,7 +349,6 @@ const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key) {
 
     return *aopt_get_desc(aopt_desc, key)->longs;
 }
-
 
 /**
  * aopt_help

--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -297,6 +297,36 @@ const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key) {
     return value;
 }
 
+const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
+    if (key == 0) {
+        log_err("Not a valid key for aopt");
+        return NULL;
+    }
+
+    const AOPT_DESC *desc = NULL;
+    int i = 0;
+
+    while(aopt_desc[i].key != 0) {
+        if(aopt_desc[i].key == key) {
+            desc = &aopt_desc[i];
+            break;
+        }
+        i++;
+    }
+
+    return desc;
+}
+
+const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key) {
+    if (key == 0) {
+        log_err("Not a valid key for aopt");
+        return NULL;
+    }
+
+    return *aopt_get_desc(aopt_desc, key)->longs;
+}
+
+
 /**
  * aopt_help
  *

--- a/src/aopt.h
+++ b/src/aopt.h
@@ -161,6 +161,34 @@ int aopt_check(const AOPT_OBJECT *aopt_obj, int key);
 const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key);
 
 /**
+ * aopt_get_desc
+ *
+ * @brief
+ *    Return AOPT Description struct of option selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to description struct - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key);
+
+/**
+ * aopt_get_long_name
+ *
+ * @brief
+ *    Return long name of option description selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to string - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key);
+
+/**
  * aopt_help
  *
  * @brief

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -157,7 +157,7 @@ double NormalCDFInverse(double p) {
     }
 
     // Approximation function is only valid for (0 < p < .5)
-    // Extend to (0 < p < 1), by taking advantage of normal CDF inverse odd symmetry shape
+    // Extend to (0 < p < 1) by taking advantage of normal CDF inverse odd symmetry shape
     // Detailed explanation here: https://www.johndcook.com/blog/normal_cdf_inverse/#basic
     if (p < 0.5) {
         // F^-1(p) = - G^-1(p)
@@ -355,8 +355,8 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
             stdDev.toDecimalUsec(), mad.toDecimalUsec(), medianad.toDecimalUsec(), siqr.toDecimalUsec(),
             coefficientOfVariance, standardError, significanceLevel, lowerInterval, upperInterval);
 
-        /* Display ERROR statistic
-         */
+        /* Display ERROR statistic*/
+
         bool isColor =
             (g_pPacketTimes->getDroppedCount(SERVER_NO) || g_pPacketTimes->getDupCount(SERVER_NO) ||
              g_pPacketTimes->getOooCount(SERVER_NO));

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -106,7 +106,6 @@ void printPercentiles(FILE *f, TicksDuration *sortedpLat, size_t size) {
                   (long unsigned)size, observationsInPercentile);
 
     log_msg_file2(f, "---> <MAX> observation = %8.3lf", sortedpLat[size - 1].toDecimalUsec());
-
     for (int i = 0; i < num; i++) {
         int index = (int)(0.5 + percentile[i] * size) - 1;
         if (index >= 0) {

--- a/src/defs.h
+++ b/src/defs.h
@@ -137,6 +137,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
 #define DEFAULT_IP_PAYLOAD_SZ (DEFAULT_IP_MTU - 28)
+#define DEFAULT_CI_SIG_LEVEL 99
 #define DUMMY_PORT 57341
 #define MAX_ACTIVE_FD_NUM                                                                          \
     1024 /* maximum number of active connection to the single TCP addr:port                        \
@@ -225,7 +226,8 @@ enum {
     OPT_DUMMY_SEND,               // 41
     OPT_RATE_LIMIT,               // 42
     OPT_UC_REUSEADDR,             // 43
-    OPT_FULL_RTT                  // 44
+    OPT_FULL_RTT,                 // 44
+    OPT_CI_SIG_LVL                // 45
 };
 
 static const char *const round_trip_str[] = { "latency", "rtt" };
@@ -677,6 +679,7 @@ struct user_params_t {
     bool increase_output_precision;  // client side only
     bool b_stream;                   // client side only
     PlaybackVector *pPlaybackVector; // client side only
+    uint32_t ci_significance_level;  // client side only
     struct sockaddr_in addr;
     int sock_type;
     bool tcp_nodelay;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -683,7 +683,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           AOPT_OPTARG,
           aopt_set_literal(0),
           aopt_set_string("ci_sig_level"),
-          "Normal confidence interval signicance level for stat reported. Values are between 0 and 100 "
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -395,6 +395,12 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           aopt_set_literal('r'),
           aopt_set_string("range"),
           "comes with -m <size>, randomly change the messages size in range: <size> +- <N>." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -587,6 +593,25 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                 }
             } else {
                 log_msg("'-%c' Invalid value", 'r');
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -1250,6 +1275,12 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
         { OPT_PLAYBACK_DATA,                                         AOPT_ARG,
           aopt_set_literal(0),                                       aopt_set_string("data-file"),
           "Pre-prepared CSV file with timestamps and message sizes." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1318,6 +1349,25 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
                 }
             } else {
                 log_msg("'-%d' Invalid value", OPT_REPLY_EVERY);
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -138,8 +138,8 @@ static const struct app_modes {
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
       { proc_mode_playback, "playback",
-        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined"
-                                                  " traffic, based on timeline and message size." },
+        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined "
+                               "traffic, based on timeline and message size." },
       { proc_mode_throughput,  "throughput",
         aopt_set_string("tp"), "Run " MODULE_NAME " client for one way throughput test." },
       { proc_mode_server, "server", aopt_set_string("sr"), "Run " MODULE_NAME " as a server." },

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -184,12 +184,15 @@ public:
 }
 
 //------------------------------------------------------------------------------
-/*static*/ TicksDuration TicksDuration::median(TicksDuration *pArr, size_t size) {
+/*static*/ TicksDuration TicksDuration::median(TicksDuration *pArr, size_t size, bool sortList) {
     if (size <= 1) return TICKS0;
     TicksDuration median(0);
 
-    sort(pArr, size);
-    if(size % 2 == 1) {
+    // Avoid worst case for quicksort: sorting large list already sorted
+    if (sortList) {
+        sort(pArr, size);
+    }
+    if (size % 2 == 1) {
         median = pArr[size/2];
     } else {
         median = (pArr[size/2 - 1] + pArr[size/2])/2;
@@ -202,7 +205,7 @@ public:
 /*static*/ TicksDuration TicksDuration::medianad(TicksDuration *pArr, size_t size) {
     if (size <= 1) return TICKS0;
 
-    TicksDuration median = TicksDuration::median(pArr, size);
+    TicksDuration median = TicksDuration::median(pArr, size, false);
     TicksDuration *deviationsFromMedian = new TicksDuration[size];
     // For details why we need 1/ppf(3/4) a.k.a. 1/NormalCDFInverse(3/4),
     // see https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation
@@ -215,7 +218,7 @@ public:
             deviationsFromMedian[i] = pArr[i] - median;
         }
     }
-    median = TicksDuration::median(deviationsFromMedian, size);
+    median = TicksDuration::median(deviationsFromMedian, size, true);
     return TicksDuration(ticks_t(median.m_ticks * scaleToConsistentEstimatorForStdDev), true);
 }
 

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -29,7 +29,6 @@
 #define __STDC_LIMIT_MACROS // for INT64_MAX in __cplusplus
 
 #include "ticks.h"
-#include "defs.h"
 
 #include <string>
 #include <stdio.h>
@@ -175,23 +174,21 @@ public:
         ticks = (double)pArr[i].m_ticks;
         sum += ticks;
     }
-
     double avg = sum / size;
-
     for (size_t i = 0; i < size; i++) {
         ticks = (double)pArr[i].m_ticks;
         distanceToAvgSummed += abs(ticks - avg);
     }
-
     double mad = distanceToAvgSummed / size;
     return TicksDuration(ticks_t(mad), true);
 }
 
 //------------------------------------------------------------------------------
-/*static*/ TicksDuration TicksDuration::getMedian(TicksDuration *pArr, size_t size) {
+/*static*/ TicksDuration TicksDuration::median(TicksDuration *pArr, size_t size) {
+    if (size <= 1) return TICKS0;
     TicksDuration median(0);
-    sort(pArr, size);
 
+    sort(pArr, size);
     if(size % 2 == 1) {
         median = pArr[size/2];
     } else {
@@ -205,9 +202,11 @@ public:
 /*static*/ TicksDuration TicksDuration::medianad(TicksDuration *pArr, size_t size) {
     if (size <= 1) return TICKS0;
 
-    TicksDuration median = TicksDuration::getMedian(pArr, size);
+    TicksDuration median = TicksDuration::median(pArr, size);
     TicksDuration *deviationsFromMedian = new TicksDuration[size];
-    double scaleToConsistentEstimatorForStdDev = 1.48260221851; // For details, see https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation
+    // For details why we need 1/ppf(3/4) a.k.a. 1/NormalCDFInverse(3/4),
+    // see https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation
+    double scaleToConsistentEstimatorForStdDev = 1.48260221851;
 
     for (size_t i = 0; i < size; i++) {
         if(pArr[i] < median) {
@@ -216,8 +215,7 @@ public:
             deviationsFromMedian[i] = pArr[i] - median;
         }
     }
-    median = TicksDuration::getMedian(deviationsFromMedian, size);
-
+    median = TicksDuration::median(deviationsFromMedian, size);
     return TicksDuration(ticks_t(median.m_ticks * scaleToConsistentEstimatorForStdDev), true);
 }
 
@@ -230,7 +228,6 @@ public:
     int p25Index = (int)(0.5 + .25 * size) - 1;
     TicksDuration p75 = sortedpArr[p75Index];
     TicksDuration p25 = sortedpArr[p25Index];
-
     TicksDuration siqr = (p75 - p25)/2;
     return siqr;
 }

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -163,6 +163,7 @@ public:
 }
 
 //------------------------------------------------------------------------------
+// Mean Absolute Deviation
 /*static*/ TicksDuration TicksDuration::mad(TicksDuration *pArr, size_t size) {
     if (size <= 1) return TICKS0;
 
@@ -184,4 +185,52 @@ public:
 
     double mad = distanceToAvgSummed / size;
     return TicksDuration(ticks_t(mad), true);
+}
+
+//------------------------------------------------------------------------------
+/*static*/ TicksDuration TicksDuration::getMedian(TicksDuration *pArr, size_t size) {
+    TicksDuration median(0);
+    sort(pArr, size);
+
+    if(size % 2 == 1) {
+        median = pArr[size/2];
+    } else {
+        median = (pArr[size/2 - 1] + pArr[size/2])/2;
+    }
+    return median;
+}
+
+//------------------------------------------------------------------------------
+// Median Absolute Deviation
+/*static*/ TicksDuration TicksDuration::medianad(TicksDuration *pArr, size_t size) {
+    if (size <= 1) return TICKS0;
+
+    TicksDuration median = TicksDuration::getMedian(pArr, size);
+    TicksDuration *deviationsFromMedian = new TicksDuration[size];
+    double scaleToConsistentEstimatorForStdDev = 1.48260221851; // For details, see https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation
+
+    for (size_t i = 0; i < size; i++) {
+        if(pArr[i] < median) {
+            deviationsFromMedian[i] = median - pArr[i];
+        } else {
+            deviationsFromMedian[i] = pArr[i] - median;
+        }
+    }
+    median = TicksDuration::getMedian(deviationsFromMedian, size);
+
+    return TicksDuration(ticks_t(median.m_ticks * scaleToConsistentEstimatorForStdDev), true);
+}
+
+//------------------------------------------------------------------------------
+// Semi-Interquartile Range
+/*static*/ TicksDuration TicksDuration::siqr(TicksDuration *sortedpArr, size_t size) {
+    if (size <= 1) return TICKS0;
+
+    int p75Index = (int)(0.5 + .75 * size) - 1;
+    int p25Index = (int)(0.5 + .25 * size) - 1;
+    TicksDuration p75 = sortedpArr[p75Index];
+    TicksDuration p25 = sortedpArr[p25Index];
+
+    TicksDuration siqr = (p75 - p25)/2;
+    return siqr;
 }

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -29,6 +29,7 @@
 #define __STDC_LIMIT_MACROS // for INT64_MAX in __cplusplus
 
 #include "ticks.h"
+#include "defs.h"
 
 #include <string>
 #include <stdio.h>
@@ -159,4 +160,28 @@ public:
     double variance = (sum_sqr - size * avg * avg) / (size - 1);
     double stdDev = sqrt(variance);
     return TicksDuration(ticks_t(stdDev + 0.5), true);
+}
+
+//------------------------------------------------------------------------------
+/*static*/ TicksDuration TicksDuration::mad(TicksDuration *pArr, size_t size) {
+    if (size <= 1) return TICKS0;
+
+    double distanceToAvgSummed = 0;
+    double sum = 0;
+    double ticks = 0;
+
+    for (size_t i = 0; i < size; i++) {
+        ticks = (double)pArr[i].m_ticks;
+        sum += ticks;
+    }
+
+    double avg = sum / size;
+
+    for (size_t i = 0; i < size; i++) {
+        ticks = (double)pArr[i].m_ticks;
+        distanceToAvgSummed += abs(ticks - avg);
+    }
+
+    double mad = distanceToAvgSummed / size;
+    return TicksDuration(ticks_t(mad), true);
 }

--- a/src/ticks.h
+++ b/src/ticks.h
@@ -355,7 +355,7 @@ public:
     static TicksDuration siqr(TicksDuration *pArr, size_t size);
 
     //------------------------------------------------------------------------------
-    static TicksDuration median(TicksDuration *pArr, size_t size);
+    static TicksDuration median(TicksDuration *pArr, size_t size, bool sortList);
 
 private:
     inline explicit TicksDuration(ticks_t _ticks, bool) : TicksBase(_ticks) {}

--- a/src/ticks.h
+++ b/src/ticks.h
@@ -348,6 +348,15 @@ public:
     //------------------------------------------------------------------------------
     static TicksDuration mad(TicksDuration *pArr, size_t size);
 
+    //------------------------------------------------------------------------------
+    static TicksDuration medianad(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration siqr(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration getMedian(TicksDuration *pArr, size_t size);
+
 private:
     inline explicit TicksDuration(ticks_t _ticks, bool) : TicksBase(_ticks) {}
     explicit TicksDuration(int64_t _nsec, int); // provide non inline function for reducing code

--- a/src/ticks.h
+++ b/src/ticks.h
@@ -345,6 +345,9 @@ public:
     //------------------------------------------------------------------------------
     static TicksDuration stdDev(TicksDuration *pArr, size_t size);
 
+    //------------------------------------------------------------------------------
+    static TicksDuration mad(TicksDuration *pArr, size_t size);
+
 private:
     inline explicit TicksDuration(ticks_t _ticks, bool) : TicksBase(_ticks) {}
     explicit TicksDuration(int64_t _nsec, int); // provide non inline function for reducing code

--- a/src/ticks.h
+++ b/src/ticks.h
@@ -355,7 +355,7 @@ public:
     static TicksDuration siqr(TicksDuration *pArr, size_t size);
 
     //------------------------------------------------------------------------------
-    static TicksDuration getMedian(TicksDuration *pArr, size_t size);
+    static TicksDuration median(TicksDuration *pArr, size_t size);
 
 private:
     inline explicit TicksDuration(ticks_t _ticks, bool) : TicksBase(_ticks) {}


### PR DESCRIPTION
**Motive:**
Compute more stats within sockperf from direct data collected. This takes advantage of sockperf's `ticks` (nanosecond precision) instead of microsecond latencies reported which an external post-processing tool would use. 

**Changes:**
- add stats: mean absolute deviation, median absolute deviation, semi-interquartile range, coefficient of variance, standard error, and confidence interval 
- confidence interval significance level configurable via `--ci_sig_level`
- inverse CDF (or ppf) function to compute confidence interval  for any significance level (0-100 exclusive)
- getter for long name of options for logging purposes
- sort latency list once where other stats can reuse

**Output example:**
Command input:  `./sockperf pp -i 127.0.0.1 -n 1000 -m 64 --ci_sig_level 80 --full-log log.txt --full-rtt`

![image](https://user-images.githubusercontent.com/20761371/108804256-c3639a80-756a-11eb-963c-53ea3cbccb45.png)
All changes are reported in magenta line `sockperf: ====> avg-rtt...`.
