### PR TITLE
Add sparce fixed bin histogram

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -144,9 +144,8 @@ void storeHistogram(int binSize, std::map<int, int> &activeBins, int minValue, i
     int startBinEdge = 0;
     int frequency = 0;
     std::map<int, int>::iterator itr;
-    FILE *f = fopen("histogram.csv", "w");
+    FILE *f = g_pApp->m_const_params.fileFullLog;
 
-    fprintf(f, "------------------------------\n");
     fprintf(f, "histogram was built using the following parameters: "
             "--h_bin_size_us=%d --h_lower_range_us=%d --h_upper_range_us=%d\n",
             (int)g_pApp->m_const_params.histogram_bin_size,
@@ -228,7 +227,6 @@ void printAndStoreHistogram(int binSize, std::map<int, int> &activeBins, int min
     }
 
     storeHistogram(binSize, activeBins, minValue, maxValue);
-    log_msg("See histogram.csv for full data");
 }
 
 //------------------------------------------------------------------------------
@@ -542,9 +540,9 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
         printPercentiles(f, sortedpLat, counter);
 
-        if(s_user_params.b_histogram) makeHistogram(sortedpLat, counter);
-
         dumpFullLog(SERVER_NO, pFullLog, counter);
+
+        if(s_user_params.b_histogram) makeHistogram(sortedpLat, counter);
     }
 
     delete[] pLat;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -97,29 +97,50 @@ void set_client_observation_timer(struct itimerval *timer, TicksTime testStart) 
 }
 
 //------------------------------------------------------------------------------
+int getStartOfRightOutlierBin(){
+    const int lowerRange = s_user_params.histogram_lower_range;
+    const int upperRange = s_user_params.histogram_upper_range;
+    const int binSize = s_user_params.histogram_bin_size;
+    int startBinEdge = upperRange;
+    /*
+        When range is not divisible by bin size, we can either truncate last bin within range to fit in
+        or have the bin overflow to keep bins a constant size. We choose to overflow which shifts outlier
+        bin.
+    */
+    int overflowRemainder = (upperRange - lowerRange) % binSize;
+
+    if(overflowRemainder != 0) {
+        startBinEdge += binSize - overflowRemainder;
+    }
+    return startBinEdge;
+} 
+
+//------------------------------------------------------------------------------
 int getLeftOutlierBinIndexReserved() {
     return 0;
 }
 
 //------------------------------------------------------------------------------
 int getRightOutlierBinIndexReserved() {
-    int lower_range = s_user_params.histogram_lower_range;
-    int upper_range = s_user_params.histogram_upper_range;
-    int bin_size = s_user_params.histogram_bin_size;
+    int lowerRange = s_user_params.histogram_lower_range;
+    int upperRange = s_user_params.histogram_upper_range;
+    int binSize = s_user_params.histogram_bin_size;
     /*
         Normal bin index for value is calculated with: 1 + (value - lower_range)/bin_size
         Right outliers all fall in the same bin which is one more than the last
         bin within range.
     */
-    return 2 + (upper_range - lower_range)/bin_size;
+    return 2 + (upperRange - lowerRange)/binSize;
 }
 
 //------------------------------------------------------------------------------
 /*  Store frequencies for each non-empty bin. All bins include only start (inclusive) as
     end (exclusive) can be inferred by adding bin size. Outlier bins include both
     start and end of bin as size depends on outliers. */
-void storeHistogram(int bin_size, int lower_range, int upper_range,
-                std::map<int, int> &active_bins, int min_value, int max_value) {
+void storeHistogram(int binSize, std::map<int, int> &activeBins, int minValue, int maxValue) {
+    const int leftOutlierBinIndex = getLeftOutlierBinIndexReserved();
+    const int rightOutlierBinIndex = getRightOutlierBinIndexReserved();
+    const int lowerRange = s_user_params.histogram_lower_range;
     int startBinEdge = 0;
     int frequency = 0;
     std::map<int, int>::iterator itr;
@@ -133,18 +154,13 @@ void storeHistogram(int bin_size, int lower_range, int upper_range,
             (int)g_pApp->m_const_params.histogram_upper_range);
     fprintf(f, "------------------------------\n");
     fprintf(f, "bin (usec), frequency\n");
-    for(itr = active_bins.begin(); itr != active_bins.end(); ++itr) {
+    for(itr = activeBins.begin(); itr != activeBins.end(); ++itr) {
         frequency = itr->second;
-        startBinEdge = (itr->first - 1) * bin_size + lower_range;
-        if (itr->first == getLeftOutlierBinIndexReserved()) {
-            fprintf(f, "%d-%d,\t\t%d\n", min_value, lower_range, frequency);
-        } else if (itr->first == getRightOutlierBinIndexReserved()) {
-            startBinEdge = upper_range;
-            int overflow_remainder = (upper_range - lower_range) % bin_size;
-            if(overflow_remainder != 0) {
-                startBinEdge += bin_size - overflow_remainder;
-            }
-            fprintf(f, "%d-%d,\t\t%d\n", startBinEdge, max_value, frequency);
+        startBinEdge = (itr->first - 1) * binSize + lowerRange;
+        if (itr->first == leftOutlierBinIndex) {
+            fprintf(f, "%d-%d,\t\t%d\n", minValue, lowerRange, frequency);
+        } else if (itr->first == rightOutlierBinIndex) {
+            fprintf(f, "%d-%d,\t\t%d\n", getStartOfRightOutlierBin(), maxValue, frequency);
         } else {
             fprintf(f, "%d,\t\t%d\n",startBinEdge, frequency);
         }
@@ -154,99 +170,99 @@ void storeHistogram(int bin_size, int lower_range, int upper_range,
 
 //------------------------------------------------------------------------------
 /*  Display histogram to fit on terminal screen width (frequency rounded up) */
-void printAndStoreHistogram(int bin_size, int lower_range, int upper_range,
-                std::map<int, int> &active_bins, int min_value, int max_value) {
-    int max_frequency = 0;
-    int terminal_width = 0;
-    int scaling_unit = 0;
-    int max_display_width = 0;
-    std::string prefix_to_histogram_display ("sockperf: bin XXX-XXX");
+void printAndStoreHistogram(int binSize, std::map<int, int> &activeBins, int minValue, int maxValue) {
+    const int leftOutlierBinIndex = getLeftOutlierBinIndexReserved();
+    const int rightOutlierBinIndex = getRightOutlierBinIndexReserved();
+    const int lowerRange = s_user_params.histogram_lower_range;
+    int maxFrequency = 0;
+    int currFrequency = 0;
+    int terminalWidth = 0;
+    int scalingUnit = 0;
+    int maxDisplayWidth = 0;
+    std::string prefixToHistogramDisplay ("sockperf: bin XXX-XXX");
     std::map<int, int>::iterator itr;
 
     // Scale to terminal
 #ifndef WIN32
     struct winsize size;
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
-    terminal_width = size.ws_col;
+    terminalWidth = size.ws_col;
 #else
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE),&csbi);
     terminal_width = csbi.dwSize.X;
 #endif
-    for(itr = active_bins.begin(); itr != active_bins.end(); ++itr) {
-        int curr_frequency = itr->second;
-        if (curr_frequency > max_frequency) {
-            max_frequency = curr_frequency;
+    for(itr = activeBins.begin(); itr != activeBins.end(); ++itr) {
+        currFrequency = itr->second;
+        if (currFrequency > maxFrequency) {
+            maxFrequency = currFrequency;
         }
     }
-    max_display_width = terminal_width - prefix_to_histogram_display.length();
-    scaling_unit = (max_frequency + max_display_width - 1)/max_display_width; // round up
+    maxDisplayWidth = terminalWidth - prefixToHistogramDisplay.length();
+    scalingUnit = (maxFrequency + maxDisplayWidth - 1)/maxDisplayWidth; // round up
 
     int startBinEdge = 0;
     int endBinEdge = 0;
     int frequency = 0;
-    int frequency_scaled_down_count = 0;
+    int frequencyScaledDownCount = 0;
 
-    if (scaling_unit == 1) {
+    if (scalingUnit == 1) {
         log_msg("[Histogram] Display to scale");
     } else {
-        log_msg("[Histogram] Display scaled to fit on screen (Key: '#' = up to %d samples)", scaling_unit);
+        log_msg("[Histogram] Display scaled to fit on screen (Key: '#' = up to %d samples)", scalingUnit);
     }
-    for(itr = active_bins.begin(); itr != active_bins.end(); ++itr) {
+    for(itr = activeBins.begin(); itr != activeBins.end(); ++itr) {
         frequency = itr->second;
-        frequency_scaled_down_count = (frequency + scaling_unit - 1) / scaling_unit; // round up
-        startBinEdge = (itr->first - 1) * bin_size + lower_range;
-        endBinEdge = startBinEdge + bin_size;
-        if (itr->first == getLeftOutlierBinIndexReserved()) {
-            log_msg("bin %d-%d " MAGNETA "%s (outliers)" ENDCOLOR, min_value, lower_range,
-                std::string(frequency_scaled_down_count, '#').c_str());
-        } else if (itr->first == getRightOutlierBinIndexReserved()) {
-            startBinEdge = upper_range;
-            int overflow_remainder = (upper_range - lower_range) % bin_size;
-            if(overflow_remainder != 0) {
-                startBinEdge += bin_size - overflow_remainder;
-            }
-            log_msg("bin %d-%d " MAGNETA "%s (outliers)" ENDCOLOR, startBinEdge, max_value,
-                std::string(frequency_scaled_down_count, '#').c_str());
+        frequencyScaledDownCount = (frequency + scalingUnit - 1) / scalingUnit; // round up
+        startBinEdge = (itr->first - 1) * binSize + lowerRange;
+        endBinEdge = startBinEdge + binSize;
+        if (itr->first == leftOutlierBinIndex) {
+            log_msg("bin %d-%d " MAGNETA "%s (outliers)" ENDCOLOR, minValue, lowerRange,
+                std::string(frequencyScaledDownCount, '#').c_str());
+        } else if (itr->first == rightOutlierBinIndex) {
+            log_msg("bin %d-%d " MAGNETA "%s (outliers)" ENDCOLOR, getStartOfRightOutlierBin(), maxValue,
+                std::string(frequencyScaledDownCount, '#').c_str());
         } else {
-            log_msg("bin %d-%d %s",startBinEdge, endBinEdge, std::string(frequency_scaled_down_count, '#').c_str());
+            log_msg("bin %d-%d %s",startBinEdge, endBinEdge, std::string(frequencyScaledDownCount, '#').c_str());
         }
     }
 
-    storeHistogram(bin_size, lower_range, upper_range, active_bins, min_value, max_value);
+    storeHistogram(binSize, activeBins, minValue, maxValue);
     log_msg("See histogram.csv for full data");
 }
 
 //------------------------------------------------------------------------------
 /* Sparce fixed bin histogram with outlier bins outside given range */
 void makeHistogram(TicksDuration *sortedpLat, size_t size) {
-    int lower_range = s_user_params.histogram_lower_range;
-    int upper_range = s_user_params.histogram_upper_range;
-    int bin_size = s_user_params.histogram_bin_size;
-    int left_outlier_bin_index = getLeftOutlierBinIndexReserved();
-    int right_outlier_bin_index = getRightOutlierBinIndexReserved();
-    int min_value = sortedpLat[0].toDecimalUsec();
-    int max_value = sortedpLat[size - 1].toDecimalUsec();
-    std::map<int, int> active_bins;
+    const int leftOutlierBinIndex = getLeftOutlierBinIndexReserved();
+    const int rightOutlierBinIndex = getRightOutlierBinIndexReserved();
+    const int lowerRange = s_user_params.histogram_lower_range;
+    const int upperRange = s_user_params.histogram_upper_range;
+    const int binSize = s_user_params.histogram_bin_size;
+    int binIndex = 0;
+    int minValue = sortedpLat[0].toDecimalUsec();
+    int maxValue = sortedpLat[size - 1].toDecimalUsec();
+    double value = 0;
+    std::map<int, int> activeBins;
     size_t i = 0;
 
     // build histogram
     for(; i < size; i++) {
-        double value = sortedpLat[i].toDecimalUsec();
-        if(value < lower_range) {
-            active_bins[left_outlier_bin_index]++;
+        value = sortedpLat[i].toDecimalUsec();
+        if(value < lowerRange) {
+            activeBins[leftOutlierBinIndex]++;
             continue;
         }
-        if(value >= upper_range) {
-            active_bins[right_outlier_bin_index]++;
+        if(value >= upperRange) {
+            activeBins[rightOutlierBinIndex]++;
             continue;
         }
-        int binIndex = 1 + (value - lower_range) / bin_size;
-        active_bins[binIndex]++;
+        binIndex = 1 + (value - lowerRange) / binSize;
+        activeBins[binIndex]++;
     }
 
-    printAndStoreHistogram(bin_size, lower_range, upper_range, active_bins, min_value, max_value);
-    active_bins.clear();
+    printAndStoreHistogram(binSize, activeBins, minValue, maxValue);
+    activeBins.clear();
 }
 
 //------------------------------------------------------------------------------

--- a/src/defs.h
+++ b/src/defs.h
@@ -227,7 +227,11 @@ enum {
     OPT_RATE_LIMIT,               // 42
     OPT_UC_REUSEADDR,             // 43
     OPT_FULL_RTT,                 // 44
-    OPT_CI_SIG_LVL                // 45
+    OPT_CI_SIG_LVL,               // 45
+    OPT_HISTOGRAM,                // 46
+    OPT_HISTOGRAM_UPPER_RANGE,    // 47
+    OPT_HISTOGRAM_LOWER_RANGE,    // 48
+    OPT_HISTOGRAM_BIN_SIZE        // 49
 };
 
 static const char *const round_trip_str[] = { "latency", "rtt" };
@@ -680,6 +684,10 @@ struct user_params_t {
     bool b_stream;                   // client side only
     PlaybackVector *pPlaybackVector; // client side only
     uint32_t ci_significance_level;  // client side only
+    bool b_histogram;                // client side only
+    uint32_t histogram_lower_range;  // client side only
+    uint32_t histogram_upper_range;  // client side only
+    uint32_t histogram_bin_size;     // client side only
     struct sockaddr_in addr;
     int sock_type;
     bool tcp_nodelay;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -401,6 +401,26 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           aopt_set_string("ci_sig_level"),
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
+        { OPT_HISTOGRAM,
+          AOPT_NOARG,
+          aopt_set_literal(0),
+          aopt_set_string("histogram"),
+          "Build histogram of latencies. " },
+        { OPT_HISTOGRAM_LOWER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_lower_range_us"),
+          "Lower range in microseconds of interest for latency histogram (default 0). " },
+        { OPT_HISTOGRAM_UPPER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_upper_range_us"),
+          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
+        { OPT_HISTOGRAM_BIN_SIZE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_bin_size_us"),
+          "Bin size in microseconds for latency histogram (default 10). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -615,6 +635,81 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
+            s_user_params.b_histogram = true;
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value < 0) {
+                        log_msg("'--%s' Invalid lower range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_lower_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
+                        log_msg("'--%s' Invalid upper range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_upper_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
+
+                    if (errno != 0 || value <= 0 || value > range) {
+                        printf("tiny value: %" PRIu32 "\n", value);
+                        log_msg("'--%s' Invalid bin size for histogram: %s.",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_bin_size = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
+            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE) )  ) {
+            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
+            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+        }
     }
 
     if (rc) {
@@ -710,6 +805,26 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           aopt_set_string("ci_sig_level"),
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
+        { OPT_HISTOGRAM,
+          AOPT_NOARG,
+          aopt_set_literal(0),
+          aopt_set_string("histogram"),
+          "Build histogram of latencies. " },
+        { OPT_HISTOGRAM_LOWER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_lower_range_us"),
+          "Lower range in microseconds of interest for latency histogram (default 0). " },
+        { OPT_HISTOGRAM_UPPER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_upper_range_us"),
+          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
+        { OPT_HISTOGRAM_BIN_SIZE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_bin_size_us"),
+          "Bin size in microseconds for latency histogram (default 10). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -941,6 +1056,81 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
+            s_user_params.b_histogram = true;
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value < 0) {
+                        log_msg("'--%s' Invalid lower range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_lower_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
+                        log_msg("'--%s' Invalid upper range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_upper_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
+
+                    if (errno != 0 || value <= 0 || value > range) {
+                        printf("tiny value: %" PRIu32 "\n", value);
+                        log_msg("'--%s' Invalid bin size for histogram: %s.",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_bin_size = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
+            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE) )  ) {
+            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
+            rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
     }
 
@@ -1281,6 +1471,26 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
           aopt_set_string("ci_sig_level"),
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
+        { OPT_HISTOGRAM,
+          AOPT_NOARG,
+          aopt_set_literal(0),
+          aopt_set_string("histogram"),
+          "Build histogram of latencies. " },
+        { OPT_HISTOGRAM_LOWER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_lower_range_us"),
+          "Lower range in microseconds of interest for latency histogram (default 0). " },
+        { OPT_HISTOGRAM_UPPER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_upper_range_us"),
+          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
+        { OPT_HISTOGRAM_BIN_SIZE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_bin_size_us"),
+          "Bin size in microseconds for latency histogram (default 10). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1370,6 +1580,81 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
                     aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
+            s_user_params.b_histogram = true;
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value < 0) {
+                        log_msg("'--%s' Invalid lower range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_lower_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
+                        log_msg("'--%s' Invalid upper range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_upper_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
+
+                    if (errno != 0 || value <= 0 || value > range) {
+                        printf("tiny value: %" PRIu32 "\n", value);
+                        log_msg("'--%s' Invalid bin size for histogram: %s.",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_bin_size = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
+            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE) )  ) {
+            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
+            rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
     }
 
@@ -2295,6 +2580,10 @@ void set_defaults() {
     s_user_params.b_server_reply_via_uc = false;
     s_user_params.b_server_dont_reply = false;
     s_user_params.b_server_detect_gaps = false;
+
+    s_user_params.histogram_lower_range = 0;
+    s_user_params.histogram_upper_range = 2000000;
+    s_user_params.histogram_bin_size = 10;
 
     s_user_params.mps = MPS_DEFAULT;
     s_user_params.reply_every = REPLY_EVERY_DEFAULT;


### PR DESCRIPTION
**Motive:**
Produce microsecond resolution histogram from measurements of sockperf tool such as latency.

**Changes:**
- Build then store histogram data in `histogram.csv` for post-processing
- Display histogram on terminal for a quick view (frequency rounded up)
- Histogram flag, bin size, lower range, and upper range of interest are configurable via cmd args
- Left and right outlier bins to capture all data below and above range

**Output Example:**

Input cmd = `./sockperf pp -i 127.0.0.1 -n 1000000 -m 64 --histogram --h_lower_range_us 25 --h_upper_range_us 60 --h_bin_size_us 1 --full-log log.txt --full-rtt`

stdout:
![image](https://user-images.githubusercontent.com/20761371/111010194-9e34a180-834a-11eb-975c-bc0e2b15eb50.png)

histogram content at the end of log file:

![image](https://user-images.githubusercontent.com/20761371/111010273-e05de300-834a-11eb-9e07-1fa3d5605883.png)

Raw:
```
------------------------------
histogram was built using the following parameters: --h_bin_size_us=1 --h_lower_range_us=25 --h_upper_range_us=60
------------------------------
bin (usec), frequency
19-25,          360
25,             462
26,             678
27,             667
28,             954
29,             2176
30,             7270
31,             22381
32,             52176
33,             95764
34,             155682
35,             208057
36,             129830
37,             99863
38,             31053
39,             16956
40,             13086
41,             10095
42,             7562
43,             6284
44,             5583
45,             5113
46,             5127
47,             5928
48,             7408
49,             10500
50,             13064
51,             13854
52,             11874
53,             8260
54,             5151
55,             3450
56,             2759
57,             2287
58,             2079
59,             1616
60-12679,               34591
------------------------------
```